### PR TITLE
Fix UI layout, REVERSE playback, and mono sample handling

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -2888,15 +2888,20 @@ function draw_envelope_page()
 end
 
 function draw_fx_page()
-    screen.level(10)
-
     -- Title
-    screen.move(4, 10)
-    screen.text("FX - REVERB (GREYHOLE)")
+    screen.level(15)
+    screen.move(4, 12)
+    screen.text("REVERB")
+
+    -- Dividing line
+    screen.level(4)
+    screen.move(4, 14)
+    screen.line(124, 14)
+    screen.stroke()
 
     -- Draw parameters with scrolling
     local params = {"Mix", "Time", "Size", "Damping", "Feedback", "Diffusion", "Mod Depth", "Mod Freq"}
-    local param_start_y = 18
+    local param_start_y = 22
     local param_spacing = 7
     local visible_params = 5
 


### PR DESCRIPTION
1. FX PAGE LAYOUT:
   - Simplified title from "FX - REVERB (GREYHOLE)" to "REVERB"
   - Moved title down to y=12 (no overlap with page header)
   - Added horizontal dividing line at y=14
   - Moved parameters down to y=22 for better spacing
   - Cleaner, more professional appearance

2. REVERSE SAMPLE BUG FIX:
   - CRITICAL: reverse parameter was defined but never used!
   - Fixed playRate calculation to apply reverse properly:
     * reverse=0 → playRate × 1 (forward)
     * reverse=1 → playRate × -1 (backward)
   - Formula: playRate * (1 - (2 * reverse))
   - Reverse playback now fully functional

3. MONO TO STEREO CONVERSION:
   - Auto-detects mono vs stereo buffers using BufChannels.kr
   - Mono samples: creates pseudo-stereo with 5ms delay on right channel
   - Stereo samples: reads normally (no change)
   - Works for both:
     * File-loaded samples
     * Recorded samples (softcut)
   - Provides natural stereo width without phase issues
   - Improves spatial imaging for mono sources

BENEFITS:
- Reverse playback finally works correctly
- Mono samples sound much better with stereo spread
- FX page more readable and professional
- No breaking changes to existing functionality

TESTING:
- Test reverse on various samples
- Test mono file loading (should have stereo width)
- Test stereo file loading (should be unchanged)
- Test recording mono input (should spread to stereo)