### PR TITLE
Fix VU meters and mono-to-stereo conversion

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -1222,8 +1222,12 @@ function init()
         elseif path == "/input_levels" then
             if state.recording then
                 -- SendReply sends values directly in args[1] and args[2]
-                state.recording_level_l = math.min(args[1] or 0, 1.0)
-                state.recording_level_r = math.min(args[2] or 0, 1.0)
+                local level_l = args[1] or 0
+                local level_r = args[2] or 0
+                state.recording_level_l = math.min(level_l, 1.0)
+                state.recording_level_r = math.min(level_r, 1.0)
+                -- Debug: uncomment to see values
+                -- print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
             end
         end
     end


### PR DESCRIPTION
VU Meters Fix:
- Improved response time (attack: 5ms, release: 50ms)
- Increased update rate from 20Hz to 30Hz for smoother display
- Added debug print option (commented out) for troubleshooting

Mono-to-Stereo Fix:
- Changed from UGen .if() method to language-level if() statement
- Use BufChannels.ir (initialization rate) instead of .kr for buffer detection
- Increased stereo delay from 5ms to 10ms for more noticeable width
- More reliable branching ensures mono samples get proper pseudo-stereo treatment

The previous implementation used .kr (control rate) which could cause issues with conditional branching. Using .ir (initialization rate) evaluates once at synth creation, which is more appropriate for buffer channel detection.