### PR TITLE
Fix VU meters: use getSynchronous instead of async get()

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -486,11 +486,12 @@ Engine_Strata : CroneEngine {
 
             // Start polling the control bus and sending OSC
             monitorPoll = Routine({
+                var levels;
                 loop {
-                    monitorBus.get({ arg val;
-                        // val is an array [peak_l, peak_r]
-                        context.server.addr.sendMsg("/input_levels", val[0], val[1]);
-                    });
+                    // Get values synchronously (blocks until ready)
+                    levels = monitorBus.getSynchronous;
+                    // levels is an array [peak_l, peak_r]
+                    context.server.addr.sendMsg("/input_levels", levels[0], levels[1]);
                     (1/30).wait; // 30Hz update rate
                 };
             }).play(SystemClock);


### PR DESCRIPTION
Critical bug fix: monitorBus.get() is asynchronous and doesn't work in a tight Routine loop. Changed to getSynchronous which blocks until values are ready, then immediately sends OSC.

This was preventing VU meters from working at all.