### PR TITLE
Add unified Play Mode feature with Chord, Strum, and Arp modes

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -486,12 +486,13 @@ Engine_Strata : CroneEngine {
 
             // Start polling the control bus and sending OSC
             monitorPoll = Routine({
-                var levels;
+                var level_l, level_r;
                 loop {
-                    // Get values synchronously (blocks until ready)
-                    levels = monitorBus.getSynchronous;
-                    // levels is an array [peak_l, peak_r]
-                    context.server.addr.sendMsg("/input_levels", levels[0], levels[1]);
+                    // Get each channel separately (getSynchronous returns single value)
+                    level_l = monitorBus.subBus(0, 1).getSynchronous;
+                    level_r = monitorBus.subBus(1, 1).getSynchronous;
+                    // Send as separate values
+                    context.server.addr.sendMsg("/input_levels", level_l, level_r);
                     (1/30).wait; // 30Hz update rate
                 };
             }).play(SystemClock);

--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -486,11 +486,12 @@ Engine_Strata : CroneEngine {
 
             // Start polling the control bus and sending OSC
             monitorPoll = Routine({
+                var levels;
                 loop {
-                    monitorBus.get({ arg val;
-                        // val is an array [peak_l, peak_r]
-                        context.server.addr.sendMsg("/input_levels", val[0], val[1]);
-                    });
+                    // Get values synchronously (blocks until ready)
+                    levels = monitorBus.getSynchronous;
+                    // levels is an array [peak_l, peak_r]
+                    context.server.addr.sendMsg("/input_levels", levels[0], levels[1]);
                     (1/30).wait; // 30Hz update rate
                 };
             }).play(SystemClock);

--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -289,51 +289,20 @@ Engine_Strata : CroneEngine {
         // Sample loading
         this.addCommand(\loadSample, "s", { arg msg;
             var path = msg[1].asString;
-            var tmpBuf;
-
             postln("Engine loading sample: " ++ path);
-
-            // Load into temporary buffer to check channel count
-            tmpBuf = Buffer.read(context.server, path, action: { arg tmpBuffer;
-                var numChannels = tmpBuffer.numChannels;
-                var numFrames = tmpBuffer.numFrames;
-                var duration = numFrames / context.server.sampleRate;
+            buffer.allocRead(path, completionMessage: {
+                var duration = buffer.numFrames / context.server.sampleRate;
+                var channels = buffer.numChannels;
 
                 postln("Sample loaded: " ++ path);
-                postln("  Frames: " ++ numFrames ++ " | Channels: " ++ numChannels ++ " | Duration: " ++ duration ++ "s");
+                postln("  Frames: " ++ buffer.numFrames ++ " | Channels: " ++ channels ++ " | Duration: " ++ duration ++ "s");
+                postln("  Mono->Stereo conversion: " ++ if(channels == 1, {"ACTIVE"}, {"not needed"}));
 
-                // Always ensure buffer is stereo
-                if(numChannels == 1, {
-                    // MONO: Convert to stereo by duplicating the mono channel
-                    postln("  Mono->Stereo conversion: duplicating channel");
-
-                    // Allocate stereo buffer with same frame count
-                    buffer.alloc(numFrames, 2, {
-                        // Copy mono data to both channels using copyData
-                        buffer.copyData(tmpBuffer, dstStartAt: 0, srcStartAt: 0, numSamples: numFrames);
-                        buffer.copyData(tmpBuffer, dstStartAt: numFrames, srcStartAt: 0, numSamples: numFrames);
-
-                        tmpBuffer.free; // Free temp buffer
-
-                        // Send duration and waveform
-                        context.server.addr.sendMsg("/sample_duration", duration);
-                        this.generateWaveform(buffer);
-                    });
-                }, {
-                    // STEREO: Direct copy
-                    postln("  Mono->Stereo conversion: not needed");
-
-                    buffer.alloc(numFrames, 2, {
-                        // Copy all stereo data
-                        buffer.copyData(tmpBuffer, dstStartAt: 0, srcStartAt: 0, numSamples: numFrames * 2);
-
-                        tmpBuffer.free; // Free temp buffer
-
-                        // Send duration and waveform
-                        context.server.addr.sendMsg("/sample_duration", duration);
-                        this.generateWaveform(buffer);
-                    });
-                });
+                // Send duration to Lua via OSC
+                context.server.addr.sendMsg("/sample_duration", duration);
+                
+                // Trigger waveform generation
+                this.generateWaveform(buffer);
             });
         });
         

--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -370,9 +370,34 @@ Engine_Strata : CroneEngine {
             reverbSynth.set(\delayTime, delayTime);
         });
 
+        this.addCommand(\setReverbSize, "f", { arg msg;
+            var size = msg[1].asFloat.clip(0.5, 5.0);
+            reverbSynth.set(\size, size);
+        });
+
         this.addCommand(\setReverbDamping, "f", { arg msg;
             var damping = msg[1].asFloat.clip(0.0, 1.0);
             reverbSynth.set(\damping, damping);
+        });
+
+        this.addCommand(\setReverbFeedback, "f", { arg msg;
+            var feedback = msg[1].asFloat.clip(0.0, 1.0);
+            reverbSynth.set(\feedback, feedback);
+        });
+
+        this.addCommand(\setReverbDiff, "f", { arg msg;
+            var diff = msg[1].asFloat.clip(0.0, 1.0);
+            reverbSynth.set(\diff, diff);
+        });
+
+        this.addCommand(\setReverbModDepth, "f", { arg msg;
+            var modDepth = msg[1].asFloat.clip(0.0, 1.0);
+            reverbSynth.set(\modDepth, modDepth);
+        });
+
+        this.addCommand(\setReverbModFreq, "f", { arg msg;
+            var modFreq = msg[1].asFloat.clip(0.1, 10.0);
+            reverbSynth.set(\modFreq, modFreq);
         });
         
         // Voice parameters

--- a/lib/midi_handler.lua
+++ b/lib/midi_handler.lua
@@ -18,6 +18,8 @@ MidiHandler.on_fader = nil
 MidiHandler.on_filter_cutoff = nil
 MidiHandler.on_filter_resonance = nil
 MidiHandler.on_voice_filter_offset = nil
+MidiHandler.on_note_on = nil
+MidiHandler.on_note_off = nil
 
 function MidiHandler.init()
     -- Connect to all MIDI devices
@@ -38,14 +40,22 @@ end
 
 function MidiHandler.process_midi(data)
     local msg = midi.to_msg(data)
-    
+
     -- Only process messages on our channel
     if msg.ch ~= MidiHandler.midi_channel then
         return
     end
-    
+
     if msg.type == "cc" then
         MidiHandler.process_cc(msg.cc, msg.val)
+    elseif msg.type == "note_on" then
+        if MidiHandler.on_note_on then
+            MidiHandler.on_note_on(msg.note, msg.vel)
+        end
+    elseif msg.type == "note_off" then
+        if MidiHandler.on_note_off then
+            MidiHandler.on_note_off(msg.note, msg.vel)
+        end
     end
 end
 

--- a/strata.lua
+++ b/strata.lua
@@ -2888,15 +2888,20 @@ function draw_envelope_page()
 end
 
 function draw_fx_page()
-    screen.level(10)
-
     -- Title
-    screen.move(4, 10)
-    screen.text("FX - REVERB (GREYHOLE)")
+    screen.level(15)
+    screen.move(4, 12)
+    screen.text("REVERB")
+
+    -- Dividing line
+    screen.level(4)
+    screen.move(4, 14)
+    screen.line(124, 14)
+    screen.stroke()
 
     -- Draw parameters with scrolling
     local params = {"Mix", "Time", "Size", "Damping", "Feedback", "Diffusion", "Mod Depth", "Mod Freq"}
-    local param_start_y = 18
+    local param_start_y = 22
     local param_spacing = 7
     local visible_params = 5
 

--- a/strata.lua
+++ b/strata.lua
@@ -214,7 +214,33 @@ local state = {
         progress = 0,
         manual_override = {}
     },
-    
+
+    -- Play mode system
+    play_mode = {
+        mode = "chord",  -- "chord", "strum", "arp"
+
+        -- Strum parameters
+        strum_rate_ms = 50,  -- 10-500ms between steps
+        strum_pattern = "up",  -- "up", "down", "updown", "random"
+
+        -- Arp parameters
+        arp_rate_div = 3,  -- Index into lfo_bpm_divisions (1/4 note default)
+        arp_pattern = "up",  -- "up", "down", "updown", "random"
+        arp_gate_length = 0.5,  -- 0.25 (staccato), 0.5 (normal), 0.9 (legato)
+        arp_source = "snapshot",  -- "snapshot" or "live"
+        arp_enabled = false,  -- Toggle arp on/off
+
+        -- Playback state
+        playing = false,
+        current_step = 1,
+        active_faders = {},  -- List of fader indices with position > threshold
+        direction = 1,  -- For updown pattern (1 or -1)
+        clock_id = nil,
+
+        -- Selected parameter for UI
+        selected_param = 1
+    },
+
     -- UI state
     current_page = 1,
     selected_param = 1,
@@ -699,6 +725,178 @@ function get_next_snapshot_index()
     end
 end
 
+-- ===================================
+-- PLAY MODE SYSTEM
+-- ===================================
+
+-- Get list of active faders (position > threshold)
+function get_active_faders()
+    local active = {}
+    for i = 0, 7 do
+        if state.faders[i].position > state.gate_threshold then
+            table.insert(active, i)
+        end
+    end
+    return active
+end
+
+-- Get next fader index based on pattern
+function get_next_play_mode_fader()
+    local active = state.play_mode.active_faders
+
+    if #active == 0 then
+        return nil
+    end
+
+    local pattern = state.play_mode.mode == "strum" and state.play_mode.strum_pattern or state.play_mode.arp_pattern
+    local step = state.play_mode.current_step
+
+    if pattern == "up" then
+        local idx = active[step]
+        state.play_mode.current_step = (step % #active) + 1
+        return idx
+
+    elseif pattern == "down" then
+        local idx = active[#active - step + 1]
+        state.play_mode.current_step = (step % #active) + 1
+        return idx
+
+    elseif pattern == "updown" then
+        -- Bounce back and forth
+        local effective_length = (#active * 2) - 2
+        if effective_length <= 0 then
+            effective_length = 1
+        end
+
+        local pos = ((step - 1) % effective_length) + 1
+        local idx
+
+        if pos <= #active then
+            idx = active[pos]
+        else
+            idx = active[#active - (pos - #active)]
+        end
+
+        state.play_mode.current_step = step + 1
+        return idx
+
+    elseif pattern == "random" then
+        local idx = active[math.random(1, #active)]
+        state.play_mode.current_step = step + 1
+        return idx
+    end
+
+    return nil
+end
+
+-- Calculate step duration based on mode
+function get_play_mode_step_duration()
+    if state.play_mode.mode == "strum" then
+        return state.play_mode.strum_rate_ms / 1000.0
+    elseif state.play_mode.mode == "arp" then
+        local bpm = state.snapshot_player.bpm
+        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats
+        return (beats / bpm) * 60.0
+    end
+    return 0.1  -- Fallback
+end
+
+-- Trigger note for a specific fader
+function trigger_play_mode_note(fader_idx)
+    local f = state.faders[fader_idx]
+    if f.position > state.gate_threshold then
+        engine.trigger(fader_idx, f.position)
+    end
+end
+
+-- Release note for a specific fader
+function release_play_mode_note(fader_idx)
+    engine.release(fader_idx)
+end
+
+-- Main playback clock
+function play_mode_clock()
+    while state.play_mode.playing do
+        -- Update active faders list (for live arp)
+        if state.play_mode.mode == "arp" and state.play_mode.arp_source == "live" then
+            state.play_mode.active_faders = get_active_faders()
+        end
+
+        -- Get next fader to trigger
+        local fader_idx = get_next_play_mode_fader()
+
+        if fader_idx then
+            -- Trigger the note
+            trigger_play_mode_note(fader_idx)
+
+            -- Handle gate length (arp mode only)
+            if state.play_mode.mode == "arp" then
+                clock.run(function()
+                    local duration = get_play_mode_step_duration()
+                    clock.sleep(duration * state.play_mode.arp_gate_length)
+                    release_play_mode_note(fader_idx)
+                end)
+            end
+        end
+
+        -- Wait for next step
+        clock.sleep(get_play_mode_step_duration())
+
+        -- Stop if strum mode and completed one cycle
+        if state.play_mode.mode == "strum" then
+            local pattern = state.play_mode.strum_pattern
+            local max_steps = #state.play_mode.active_faders
+
+            if pattern == "updown" then
+                max_steps = (max_steps * 2) - 2
+                if max_steps <= 0 then
+                    max_steps = 1
+                end
+            end
+
+            if state.play_mode.current_step > max_steps then
+                stop_play_mode()
+            end
+        end
+    end
+end
+
+-- Start play mode (called when snapshot triggers or arp toggled)
+function start_play_mode(source_faders)
+    -- Capture fader positions
+    state.play_mode.active_faders = source_faders or get_active_faders()
+
+    if #state.play_mode.active_faders == 0 then
+        return  -- Nothing to play
+    end
+
+    -- Stop existing playback
+    if state.play_mode.playing then
+        stop_play_mode()
+    end
+
+    -- Reset state
+    state.play_mode.current_step = 1
+    state.play_mode.direction = 1
+    state.play_mode.playing = true
+
+    -- Start clock
+    state.play_mode.clock_id = clock.run(play_mode_clock)
+end
+
+-- Stop play mode
+function stop_play_mode()
+    state.play_mode.playing = false
+    if state.play_mode.clock_id then
+        clock.cancel(state.play_mode.clock_id)
+        state.play_mode.clock_id = nil
+    end
+end
+
+-- ===================================
+-- MORPHING & SNAPSHOTS
+-- ===================================
+
 function start_morph(to_idx)
     if to_idx == "rest" then
         -- Morph all faders to zero
@@ -749,8 +947,22 @@ function start_morph(to_idx)
     end
     
     state.snapshot_current = to_idx
-    
+
     print("Morphing to snapshot " .. to_idx)
+
+    -- Trigger play mode if strum is enabled
+    if state.play_mode.mode == "strum" then
+        -- Get active faders from the target snapshot
+        local active_faders = {}
+        for i = 0, 7 do
+            if state.snapshots[to_idx].positions[i] > state.gate_threshold then
+                table.insert(active_faders, i)
+            end
+        end
+        if #active_faders > 0 then
+            start_play_mode(active_faders)
+        end
+    end
 end
 
 function jump_to_snapshot(idx)
@@ -1001,7 +1213,16 @@ function save_scene(slot)
         snapshot_player_euclidean_pulses = state.snapshot_player.euclidean_pulses,
         snapshot_player_euclidean_steps = state.snapshot_player.euclidean_steps,
         snapshot_player_euclidean_rotation = state.snapshot_player.euclidean_rotation,
-        snapshot_player_euclidean_rest_behavior = state.snapshot_player.euclidean_rest_behavior
+        snapshot_player_euclidean_rest_behavior = state.snapshot_player.euclidean_rest_behavior,
+
+        -- Play mode
+        play_mode_mode = state.play_mode.mode,
+        play_mode_strum_rate_ms = state.play_mode.strum_rate_ms,
+        play_mode_strum_pattern = state.play_mode.strum_pattern,
+        play_mode_arp_rate_div = state.play_mode.arp_rate_div,
+        play_mode_arp_pattern = state.play_mode.arp_pattern,
+        play_mode_arp_gate_length = state.play_mode.arp_gate_length,
+        play_mode_arp_source = state.play_mode.arp_source
     }
     
     -- Deep copy snapshots
@@ -1127,7 +1348,22 @@ function load_scene(slot)
     state.snapshot_player.euclidean_steps = scene.snapshot_player_euclidean_steps
     state.snapshot_player.euclidean_rotation = scene.snapshot_player_euclidean_rotation
     state.snapshot_player.euclidean_rest_behavior = scene.snapshot_player_euclidean_rest_behavior
-    
+
+    -- Load play mode
+    state.play_mode.mode = scene.play_mode_mode or "chord"
+    state.play_mode.strum_rate_ms = scene.play_mode_strum_rate_ms or 50
+    state.play_mode.strum_pattern = scene.play_mode_strum_pattern or "up"
+    state.play_mode.arp_rate_div = scene.play_mode_arp_rate_div or 3
+    state.play_mode.arp_pattern = scene.play_mode_arp_pattern or "up"
+    state.play_mode.arp_gate_length = scene.play_mode_arp_gate_length or 0.5
+    state.play_mode.arp_source = scene.play_mode_arp_source or "snapshot"
+
+    -- Stop any active arp if loading scene
+    if state.play_mode.playing then
+        stop_play_mode()
+    end
+    state.play_mode.arp_enabled = false
+
     -- Reset sequencer state
     state.snapshot_player.pattern_position = 1
     state.snapshot_player.euclidean_pattern = {}
@@ -1795,10 +2031,10 @@ function enc(n, delta)
     if n == 1 then
     -- Page navigation
     local old_page = state.current_page
-    state.current_page = util.clamp(state.current_page + delta, 1, 10)
-    
+    state.current_page = util.clamp(state.current_page + delta, 1, 11)
+
     -- Reset parameter selection when entering LFO page
-    if state.current_page == 9 and old_page ~= 9 then
+    if state.current_page == 10 and old_page ~= 10 then
         state.lfo_selected_param = 1
         -- Also ensure lfo_selected is valid
         state.lfo_selected = util.clamp(state.lfo_selected, 1, state.lfo_count)
@@ -1938,8 +2174,111 @@ function enc(n, delta)
                 state.snapshot_selected = util.wrap(state.snapshot_selected + delta, 1, 8)
             end
         end
-        
+
     elseif state.current_page == 4 then
+        -- PLAY MODE page
+        if n == 2 then
+            local max_params = 1
+            if state.play_mode.mode == "strum" then
+                max_params = 3
+            elseif state.play_mode.mode == "arp" then
+                max_params = 6
+            end
+            state.play_mode.selected_param = util.wrap(state.play_mode.selected_param + delta, 1, max_params)
+        elseif n == 3 then
+            if state.play_mode.selected_param == 1 then
+                -- Mode selection
+                local modes = {"chord", "strum", "arp"}
+                local current_idx = 1
+                for i, m in ipairs(modes) do
+                    if m == state.play_mode.mode then
+                        current_idx = i
+                        break
+                    end
+                end
+                local next_idx = util.wrap(current_idx + delta, 1, 3)
+                local old_mode = state.play_mode.mode
+                state.play_mode.mode = modes[next_idx]
+
+                -- Stop arp if switching away from arp mode
+                if old_mode == "arp" and state.play_mode.playing then
+                    stop_play_mode()
+                    state.play_mode.arp_enabled = false
+                end
+
+                -- Reset selected param when mode changes
+                state.play_mode.selected_param = 1
+
+            elseif state.play_mode.mode == "strum" then
+                if state.play_mode.selected_param == 2 then
+                    -- Strum rate
+                    state.play_mode.strum_rate_ms = util.clamp(
+                        state.play_mode.strum_rate_ms + (delta * 10), 10, 500
+                    )
+                elseif state.play_mode.selected_param == 3 then
+                    -- Strum pattern
+                    local patterns = {"up", "down", "updown", "random"}
+                    local current_idx = 1
+                    for i, p in ipairs(patterns) do
+                        if p == state.play_mode.strum_pattern then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 4)
+                    state.play_mode.strum_pattern = patterns[next_idx]
+                end
+
+            elseif state.play_mode.mode == "arp" then
+                if state.play_mode.selected_param == 2 then
+                    -- Arp rate (BPM division)
+                    state.play_mode.arp_rate_div = util.wrap(
+                        state.play_mode.arp_rate_div + delta, 1, #state.lfo_bpm_divisions
+                    )
+                elseif state.play_mode.selected_param == 3 then
+                    -- Arp pattern
+                    local patterns = {"up", "down", "updown", "random"}
+                    local current_idx = 1
+                    for i, p in ipairs(patterns) do
+                        if p == state.play_mode.arp_pattern then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 4)
+                    state.play_mode.arp_pattern = patterns[next_idx]
+                elseif state.play_mode.selected_param == 4 then
+                    -- Gate length
+                    local gates = {0.25, 0.5, 0.9}
+                    local current_idx = 2  -- Default to 0.5
+                    for i, g in ipairs(gates) do
+                        if math.abs(g - state.play_mode.arp_gate_length) < 0.01 then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 3)
+                    state.play_mode.arp_gate_length = gates[next_idx]
+                elseif state.play_mode.selected_param == 5 then
+                    -- Source
+                    if delta ~= 0 then
+                        state.play_mode.arp_source = (state.play_mode.arp_source == "snapshot") and "live" or "snapshot"
+                    end
+                elseif state.play_mode.selected_param == 6 then
+                    -- Active toggle
+                    if delta ~= 0 then
+                        state.play_mode.arp_enabled = not state.play_mode.arp_enabled
+                        if state.play_mode.arp_enabled then
+                            start_play_mode()
+                        else
+                            stop_play_mode()
+                        end
+                    end
+                end
+            end
+        end
+
+    elseif state.current_page == 5 then
         -- SEQUENCER page
         if n == 2 then
             -- Determine number of params based on mode
@@ -2045,7 +2384,7 @@ function enc(n, delta)
             end
         end
     
-    elseif state.current_page == 5 then
+    elseif state.current_page == 6 then
         -- ENVELOPE page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 5)
@@ -2071,7 +2410,7 @@ function enc(n, delta)
             end
         end
         
-    elseif state.current_page == 6 then
+    elseif state.current_page == 7 then
         -- SCALE page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 3)
@@ -2088,7 +2427,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 7 then
+    elseif state.current_page == 8 then
         -- FX page (reverb)
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 8)
@@ -2128,7 +2467,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 8 then
+    elseif state.current_page == 9 then
         -- MIDI settings page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 2)
@@ -2142,7 +2481,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 9 then
+    elseif state.current_page == 10 then
         -- LFO page
         if n == 2 then
             -- E2: Select parameter
@@ -2210,7 +2549,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 10 then
+    elseif state.current_page == 11 then
         -- SCENES page
         if n == 2 then
             state.scene_selected = util.wrap(state.scene_selected + delta, 1, 8)
@@ -2267,7 +2606,24 @@ function key(n, z)
                 else
                     jump_to_snapshot(state.snapshot_selected)
                 end
-            elseif state.current_page == 4 then 
+            elseif state.current_page == 4 then
+                -- PLAY MODE page: K2 action depends on mode
+                if state.play_mode.mode == "strum" then
+                    -- Manual strum trigger
+                    local active = get_active_faders()
+                    if #active > 0 then
+                        start_play_mode(active)
+                    end
+                elseif state.play_mode.mode == "arp" then
+                    -- Toggle arp on/off
+                    state.play_mode.arp_enabled = not state.play_mode.arp_enabled
+                    if state.play_mode.arp_enabled then
+                        start_play_mode()
+                    else
+                        stop_play_mode()
+                    end
+                end
+            elseif state.current_page == 5 then
                 -- SEQUENCER page
                 if state.snapshot_player.mode == "pattern" then
                     pattern_add_snapshot()
@@ -2280,7 +2636,7 @@ function key(n, z)
                     show_notification("REST: " .. string.upper(state.snapshot_player.euclidean_rest_behavior), 1.5)
                     save_snapshots_to_disk()
                 end
-            elseif state.current_page == 9 then
+            elseif state.current_page == 10 then
                 -- LFO page
                 local lfo = state.lfos[state.lfo_selected]
 
@@ -2299,7 +2655,7 @@ function key(n, z)
                         lfo.dest_param = util.wrap(lfo.dest_param + 1, dest.param_min, dest.param_max)
                     end
                 end
-            elseif state.current_page == 10 then
+            elseif state.current_page == 11 then
                 -- SCENES page: Save scene
                 save_scene(state.scene_selected)
             end
@@ -2329,6 +2685,9 @@ function key(n, z)
                     toggle_snapshot_enabled(state.snapshot_selected)
                 end
             elseif state.current_page == 4 then
+                -- PLAY MODE page: K3 reserved for future use
+                -- (no action currently)
+            elseif state.current_page == 5 then
                 -- SEQUENCER page
                 if state.snapshot_player.mode == "live" then
                     show_notification("LIVE MODE", 1.5)
@@ -2345,7 +2704,7 @@ function key(n, z)
                         start_snapshot_sequencer()
                     end
                 end
-            elseif state.current_page == 10 then
+            elseif state.current_page == 11 then
                 -- SCENES page
                 if state.k1_held then
                     clear_scene(state.scene_selected)
@@ -2367,7 +2726,7 @@ function redraw()
 
     screen.level(15)
     screen.move(64, 8)
-    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "SEQUENCER", "ENVELOPE", "SCALE", "FX", "MIDI", "LFO", "SCENES"}
+    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "PLAY MODE", "SEQUENCER", "ENVELOPE", "SCALE", "FX", "MIDI", "LFO", "SCENES"}
     screen.text_center(pages[state.current_page])
 
     if state.current_page == 1 then
@@ -2377,18 +2736,20 @@ function redraw()
     elseif state.current_page == 3 then
         draw_snapshots_page()
     elseif state.current_page == 4 then
-        draw_sequencer_page()
+        draw_play_mode_page()
     elseif state.current_page == 5 then
-        draw_envelope_page()
+        draw_sequencer_page()
     elseif state.current_page == 6 then
-        draw_scale_page()
+        draw_envelope_page()
     elseif state.current_page == 7 then
-        draw_fx_page()
+        draw_scale_page()
     elseif state.current_page == 8 then
-        draw_midi_page()
+        draw_fx_page()
     elseif state.current_page == 9 then
-        draw_lfo_page()
+        draw_midi_page()
     elseif state.current_page == 10 then
+        draw_lfo_page()
+    elseif state.current_page == 11 then
         draw_scenes_page()
     end
 
@@ -2764,6 +3125,104 @@ function draw_snapshots_page()
     screen.level(6)
     screen.move(4, 64)
     screen.text("K2:Jump  K3:En/Dis  K1+K3:Del")
+end
+
+function draw_play_mode_page()
+    screen.level(10)
+
+    local y_offset = 18
+    local line_height = 10
+    local current_line = 0
+
+    -- Mode (always shown, param 1)
+    screen.level(state.play_mode.selected_param == 1 and 15 or 6)
+    screen.move(4, y_offset + (current_line * line_height))
+    local mode_display = state.play_mode.mode == "chord" and "Chord" or
+                         state.play_mode.mode == "strum" and "Strum" or "Arp"
+    screen.text("Mode: " .. mode_display)
+    current_line = current_line + 1
+
+    -- Mode-specific parameters
+    if state.play_mode.mode == "strum" then
+        -- Rate (param 2)
+        screen.level(state.play_mode.selected_param == 2 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("Rate: " .. state.play_mode.strum_rate_ms .. "ms")
+        current_line = current_line + 1
+
+        -- Pattern (param 3)
+        screen.level(state.play_mode.selected_param == 3 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local pattern_display = state.play_mode.strum_pattern == "updown" and "Up-Down" or
+                                string.upper(state.play_mode.strum_pattern:sub(1,1)) ..
+                                state.play_mode.strum_pattern:sub(2)
+        screen.text("Pattern: " .. pattern_display)
+        current_line = current_line + 1
+
+        -- K2 help text
+        screen.level(8)
+        screen.move(4, y_offset + (current_line * line_height) + 5)
+        screen.text("K2: Trigger Strum")
+
+    elseif state.play_mode.mode == "arp" then
+        -- Rate (param 2)
+        screen.level(state.play_mode.selected_param == 2 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local rate_name = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].name
+        screen.text("Rate: " .. rate_name)
+        current_line = current_line + 1
+
+        -- Pattern (param 3)
+        screen.level(state.play_mode.selected_param == 3 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local pattern_display = state.play_mode.arp_pattern == "updown" and "Up-Down" or
+                                string.upper(state.play_mode.arp_pattern:sub(1,1)) ..
+                                state.play_mode.arp_pattern:sub(2)
+        screen.text("Pattern: " .. pattern_display)
+        current_line = current_line + 1
+
+        -- Gate (param 4)
+        screen.level(state.play_mode.selected_param == 4 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local gate_name = state.play_mode.arp_gate_length == 0.25 and "Staccato" or
+                          state.play_mode.arp_gate_length == 0.5 and "Normal" or "Legato"
+        screen.text("Gate: " .. gate_name)
+        current_line = current_line + 1
+
+        -- Source (param 5)
+        screen.level(state.play_mode.selected_param == 5 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local source_display = string.upper(state.play_mode.arp_source:sub(1,1)) ..
+                               state.play_mode.arp_source:sub(2)
+        screen.text("Source: " .. source_display)
+        current_line = current_line + 1
+
+        -- Active (param 6)
+        screen.level(state.play_mode.selected_param == 6 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("Active: " .. (state.play_mode.arp_enabled and "On" or "Off"))
+        current_line = current_line + 1
+
+        -- Status indicator
+        if state.play_mode.arp_enabled and state.play_mode.playing then
+            screen.level(15)
+            screen.move(128, y_offset)
+            screen.text_right("⏵")
+        end
+
+        -- K2 help text
+        screen.level(8)
+        screen.move(4, 64)
+        screen.text("K2: Toggle Arp")
+    else
+        -- Chord mode - just show description
+        screen.level(8)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("All faders trigger")
+        current_line = current_line + 1
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("simultaneously")
+    end
 end
 
 function draw_sequencer_page()

--- a/strata.lua
+++ b/strata.lua
@@ -1222,8 +1222,12 @@ function init()
         elseif path == "/input_levels" then
             if state.recording then
                 -- SendReply sends values directly in args[1] and args[2]
-                state.recording_level_l = math.min(args[1] or 0, 1.0)
-                state.recording_level_r = math.min(args[2] or 0, 1.0)
+                local level_l = args[1] or 0
+                local level_r = args[2] or 0
+                state.recording_level_l = math.min(level_l, 1.0)
+                state.recording_level_r = math.min(level_r, 1.0)
+                -- Debug: uncomment to see values
+                -- print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
             end
         end
     end

--- a/strata.lua
+++ b/strata.lua
@@ -2267,10 +2267,10 @@ function key(n, z)
                     show_notification("REST: " .. string.upper(state.snapshot_player.euclidean_rest_behavior), 1.5)
                     save_snapshots_to_disk()
                 end
-            elseif state.current_page == 8 then
+            elseif state.current_page == 9 then
                 -- LFO page
                 local lfo = state.lfos[state.lfo_selected]
-                
+
                 if state.lfo_selected_param == 1 then
                     lfo.enabled = not lfo.enabled
                 elseif state.lfo_selected_param == 2 then
@@ -2286,7 +2286,7 @@ function key(n, z)
                         lfo.dest_param = util.wrap(lfo.dest_param + 1, dest.param_min, dest.param_max)
                     end
                 end
-            elseif state.current_page == 9 then
+            elseif state.current_page == 10 then
                 -- SCENES page: Save scene
                 save_scene(state.scene_selected)
             end
@@ -2332,7 +2332,7 @@ function key(n, z)
                         start_snapshot_sequencer()
                     end
                 end
-            elseif state.current_page == 9 then
+            elseif state.current_page == 10 then
                 -- SCENES page
                 if state.k1_held then
                     clear_scene(state.scene_selected)

--- a/strata.lua
+++ b/strata.lua
@@ -1221,13 +1221,14 @@ function init()
             print("Sample duration: " .. string.format("%.2f", state.sample_duration) .. "s")
         elseif path == "/input_levels" then
             if state.recording then
-                -- SendReply sends values directly in args[1] and args[2]
+                -- SendPeakRMS sends: [peak_l, peak_r, rms_l, rms_r]
+                -- We use peak values (args[1], args[2]) for VU meters
                 local level_l = args[1] or 0
                 local level_r = args[2] or 0
                 state.recording_level_l = math.min(level_l, 1.0)
                 state.recording_level_r = math.min(level_r, 1.0)
                 -- Debug: uncomment to see values
-                -- print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
+                print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
             end
         end
     end

--- a/strata.lua
+++ b/strata.lua
@@ -793,11 +793,11 @@ end
 -- Calculate step duration based on mode
 function get_play_mode_step_duration()
     if state.play_mode.mode == "strum" then
-        return state.play_mode.strum_rate_ms / 1000.0
+        return math.max(state.play_mode.strum_rate_ms / 1000.0, 0.01)
     elseif state.play_mode.mode == "arp" then
-        local bpm = state.snapshot_player.bpm
-        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats
-        return (beats / bpm) * 60.0
+        local bpm = math.max(state.snapshot_player.bpm or 120, 1)  -- Prevent division by zero
+        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats or 1.0
+        return math.max((beats / bpm) * 60.0, 0.01)  -- Minimum 10ms
     end
     return 0.1  -- Fallback
 end

--- a/strata.lua
+++ b/strata.lua
@@ -963,19 +963,24 @@ function start_morph(to_idx)
     state.morphing.to_positions = state.snapshots[to_idx].positions
     state.morphing.start_time = util.time()
     state.morphing.progress = 0
-    state.morphing.active = true
-    
+
     -- Reset manual override flags
     for i = 0, 7 do
         state.morphing.manual_override[i] = false
     end
-    
+
     state.snapshot_current = to_idx
 
     print("Morphing to snapshot " .. to_idx)
 
-    -- Trigger play mode if strum or arp is enabled
-    if state.play_mode.mode == "strum" or (state.play_mode.mode == "arp" and state.play_mode.arp_source == "snapshot") then
+    -- Check if we should use play mode or normal morphing
+    local use_play_mode = state.play_mode.mode == "strum" or
+                          (state.play_mode.mode == "arp" and state.play_mode.arp_source == "snapshot")
+
+    if use_play_mode then
+        -- In strum/arp mode: skip normal morphing, let play mode handle it
+        state.morphing.active = false
+
         -- Get active faders and their target positions from the snapshot
         local active_faders = {}
         local target_positions = {}
@@ -989,6 +994,9 @@ function start_morph(to_idx)
         if #active_faders > 0 then
             start_play_mode(active_faders, target_positions)
         end
+    else
+        -- Normal chord mode: use standard morphing
+        state.morphing.active = true
     end
 end
 

--- a/strata.lua
+++ b/strata.lua
@@ -234,6 +234,7 @@ local state = {
         playing = false,
         current_step = 1,
         active_faders = {},  -- List of fader indices with position > threshold
+        target_positions = {},  -- Target positions for each fader (for strum/arp from snapshots)
         direction = 1,  -- For updown pattern (1 or -1)
         clock_id = nil,
 
@@ -803,9 +804,10 @@ end
 
 -- Trigger note for a specific fader
 function trigger_play_mode_note(fader_idx)
-    local f = state.faders[fader_idx]
-    if f.position > state.gate_threshold then
-        engine.trigger(fader_idx, f.position)
+    -- Use stored target position if available, otherwise use current position
+    local position = state.play_mode.target_positions[fader_idx] or state.faders[fader_idx].position
+    if position > state.gate_threshold then
+        engine.trigger(fader_idx, position)
     end
 end
 
@@ -817,9 +819,13 @@ end
 -- Main playback clock
 function play_mode_clock()
     while state.play_mode.playing do
-        -- Update active faders list (for live arp)
+        -- Update active faders list and positions (for live arp)
         if state.play_mode.mode == "arp" and state.play_mode.arp_source == "live" then
             state.play_mode.active_faders = get_active_faders()
+            -- Update target positions from current fader positions
+            for i = 0, 7 do
+                state.play_mode.target_positions[i] = state.faders[i].position
+            end
         end
 
         -- Get next fader to trigger
@@ -862,9 +868,20 @@ function play_mode_clock()
 end
 
 -- Start play mode (called when snapshot triggers or arp toggled)
-function start_play_mode(source_faders)
+function start_play_mode(source_faders, target_positions)
     -- Capture fader positions
     state.play_mode.active_faders = source_faders or get_active_faders()
+
+    -- Store target positions (if provided, used for strum/arp from snapshots)
+    if target_positions then
+        state.play_mode.target_positions = target_positions
+    else
+        -- For live mode, use current fader positions
+        state.play_mode.target_positions = {}
+        for i = 0, 7 do
+            state.play_mode.target_positions[i] = state.faders[i].position
+        end
+    end
 
     if #state.play_mode.active_faders == 0 then
         return  -- Nothing to play
@@ -950,17 +967,20 @@ function start_morph(to_idx)
 
     print("Morphing to snapshot " .. to_idx)
 
-    -- Trigger play mode if strum is enabled
-    if state.play_mode.mode == "strum" then
-        -- Get active faders from the target snapshot
+    -- Trigger play mode if strum or arp is enabled
+    if state.play_mode.mode == "strum" or (state.play_mode.mode == "arp" and state.play_mode.arp_source == "snapshot") then
+        -- Get active faders and their target positions from the snapshot
         local active_faders = {}
+        local target_positions = {}
         for i = 0, 7 do
-            if state.snapshots[to_idx].positions[i] > state.gate_threshold then
+            local pos = state.snapshots[to_idx].positions[i]
+            target_positions[i] = pos
+            if pos > state.gate_threshold then
                 table.insert(active_faders, i)
             end
         end
         if #active_faders > 0 then
-            start_play_mode(active_faders)
+            start_play_mode(active_faders, target_positions)
         end
     end
 end

--- a/strata.lua
+++ b/strata.lua
@@ -237,6 +237,7 @@ local state = {
         target_positions = {},  -- Target positions for each fader (for strum/arp from snapshots)
         direction = 1,  -- For updown pattern (1 or -1)
         clock_id = nil,
+        initialized = false,  -- Prevent starting before clocks are ready
 
         -- Selected parameter for UI
         selected_param = 1
@@ -876,6 +877,11 @@ end
 
 -- Start play mode (called when snapshot triggers or arp toggled)
 function start_play_mode(source_faders, target_positions)
+    -- Don't start if not initialized yet
+    if not state.play_mode.initialized then
+        return
+    end
+
     -- Capture fader positions
     state.play_mode.active_faders = source_faders or get_active_faders()
 
@@ -1569,6 +1575,9 @@ function init()
             redraw()
         end
     end)
+
+    -- Enable play mode now that everything is initialized
+    state.play_mode.initialized = true
 end
 
 -- Morph clock - handles interpolation

--- a/strata.lua
+++ b/strata.lua
@@ -130,7 +130,7 @@ local state = {
     },
     
     -- LFO shape names
-    lfo_shape_names = {"Sine", "Triangle", "Square", "Random"},
+    lfo_shape_names = {"Sine", "Triangle", "Square", "Random", "Smooth Random"},
     
     -- LFO BPM divisions
     lfo_bpm_divisions = {
@@ -238,6 +238,7 @@ end
 -- Initialize LFO random values
 for i = 1, state.lfo_count do
     state.lfos[i].random_value = 0
+    state.lfos[i].next_random_value = (math.random() * 2) - 1
     state.lfos[i].last_phase = 0
 end
 
@@ -275,8 +276,20 @@ function calculate_lfo_value(lfo)
             lfo.random_value = (math.random() * 2) - 1
         end
         value = lfo.random_value or 0
+    elseif lfo.shape == 5 then
+        -- Smooth Random (interpolated random)
+        -- Smoothly glides from one random value to the next
+        if phase < lfo.last_phase then
+            -- Phase wrapped - move to next random value
+            lfo.random_value = lfo.next_random_value or 0
+            lfo.next_random_value = (math.random() * 2) - 1
+        end
+        -- Linear interpolation between current and next random value
+        local current = lfo.random_value or 0
+        local next = lfo.next_random_value or 0
+        value = current + (next - current) * phase
     end
-    
+
     lfo.last_phase = phase
     return value
 end
@@ -1931,7 +1944,7 @@ function enc(n, delta)
                 end
             elseif state.lfo_selected_param == 3 then
                 -- Shape
-                lfo.shape = util.wrap(lfo.shape + delta, 1, 4)
+                lfo.shape = util.wrap(lfo.shape + delta, 1, 5)
             elseif state.lfo_selected_param == 4 then
                 -- Rate mode
                 if delta ~= 0 then

--- a/strata.lua
+++ b/strata.lua
@@ -1227,7 +1227,7 @@ function init()
                 state.recording_level_l = math.min(level_l, 1.0)
                 state.recording_level_r = math.min(level_r, 1.0)
                 -- Debug: uncomment to see values
-                -- print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
+                 print("VU: L=" .. string.format("%.3f", level_l) .. " R=" .. string.format("%.3f", level_r))
             end
         end
     end

--- a/strata.lua
+++ b/strata.lua
@@ -807,13 +807,20 @@ function trigger_play_mode_note(fader_idx)
     -- Use stored target position if available, otherwise use current position
     local position = state.play_mode.target_positions[fader_idx] or state.faders[fader_idx].position
     if position > state.gate_threshold then
-        engine.trigger(fader_idx, position)
+        -- Temporarily set fader position to target for amplitude control
+        local old_pos = state.faders[fader_idx].position
+        state.faders[fader_idx].position = position
+
+        -- Use existing trigger_note function which handles frequency calculation and engine calls
+        trigger_note(fader_idx)
+
+        -- Note: Don't restore old position - let it stay at target for play mode
     end
 end
 
 -- Release note for a specific fader
 function release_play_mode_note(fader_idx)
-    engine.release(fader_idx)
+    release_note(fader_idx)
 end
 
 -- Main playback clock

--- a/strata.lua
+++ b/strata.lua
@@ -1923,16 +1923,16 @@ function enc(n, delta)
             state.selected_param = util.wrap(state.selected_param + delta, 1, 3)
         elseif n == 3 then
             if state.selected_param == 1 then
-                -- Reverb Mix
-                state.reverb_mix = util.clamp(state.reverb_mix + (delta * 0.05), 0.0, 1.0)
+                -- Reverb Mix (1% increments)
+                state.reverb_mix = util.clamp(state.reverb_mix + (delta * 0.01), 0.0, 1.0)
                 engine.setReverbMix(state.reverb_mix)
             elseif state.selected_param == 2 then
                 -- Reverb Time
                 state.reverb_time = util.clamp(state.reverb_time + (delta * 0.1), 0.1, 10.0)
                 engine.setReverbTime(state.reverb_time)
             elseif state.selected_param == 3 then
-                -- Reverb Damping
-                state.reverb_damping = util.clamp(state.reverb_damping + (delta * 0.05), 0.0, 1.0)
+                -- Reverb Damping (1% increments)
+                state.reverb_damping = util.clamp(state.reverb_damping + (delta * 0.01), 0.0, 1.0)
                 engine.setReverbDamping(state.reverb_damping)
             end
         end

--- a/strata.lua
+++ b/strata.lua
@@ -1630,10 +1630,10 @@ function enc(n, delta)
     if n == 1 then
     -- Page navigation
     local old_page = state.current_page
-    state.current_page = util.clamp(state.current_page + delta, 1, 9)
+    state.current_page = util.clamp(state.current_page + delta, 1, 10)
     
     -- Reset parameter selection when entering LFO page
-    if state.current_page == 8 and old_page ~= 8 then
+    if state.current_page == 9 and old_page ~= 9 then
         state.lfo_selected_param = 1
         -- Also ensure lfo_selected is valid
         state.lfo_selected = util.clamp(state.lfo_selected, 1, state.lfo_count)
@@ -1881,42 +1881,22 @@ function enc(n, delta)
         end
     
     elseif state.current_page == 5 then
-        -- ENVELOPE page (now includes reverb)
+        -- ENVELOPE page
         if n == 2 then
-            state.selected_param = util.wrap(state.selected_param + delta, 1, 7)
+            state.selected_param = util.wrap(state.selected_param + delta, 1, 4)
         elseif n == 3 then
             if state.selected_param == 1 then
                 state.env_attack = util.clamp(state.env_attack + (delta * 0.01), 0.001, 2.0)
-                for i = 0, state.num_faders - 1 do
-                    engine.setVoiceEnvelope(i, state.env_attack, state.env_decay, state.env_sustain, state.env_release)
-                end
             elseif state.selected_param == 2 then
                 state.env_decay = util.clamp(state.env_decay + (delta * 0.01), 0.01, 2.0)
-                for i = 0, state.num_faders - 1 do
-                    engine.setVoiceEnvelope(i, state.env_attack, state.env_decay, state.env_sustain, state.env_release)
-                end
             elseif state.selected_param == 3 then
                 state.env_sustain = util.clamp(state.env_sustain + (delta * 0.05), 0, 1.0)
-                for i = 0, state.num_faders - 1 do
-                    engine.setVoiceEnvelope(i, state.env_attack, state.env_decay, state.env_sustain, state.env_release)
-                end
             elseif state.selected_param == 4 then
                 state.env_release = util.clamp(state.env_release + (delta * 0.05), 0.01, 5.0)
-                for i = 0, state.num_faders - 1 do
-                    engine.setVoiceEnvelope(i, state.env_attack, state.env_decay, state.env_sustain, state.env_release)
-                end
-            elseif state.selected_param == 5 then
-                -- Reverb Mix
-                state.reverb_mix = util.clamp(state.reverb_mix + (delta * 0.05), 0.0, 1.0)
-                engine.setReverbMix(state.reverb_mix)
-            elseif state.selected_param == 6 then
-                -- Reverb Time
-                state.reverb_time = util.clamp(state.reverb_time + (delta * 0.1), 0.1, 10.0)
-                engine.setReverbTime(state.reverb_time)
-            elseif state.selected_param == 7 then
-                -- Reverb Damping
-                state.reverb_damping = util.clamp(state.reverb_damping + (delta * 0.05), 0.0, 1.0)
-                engine.setReverbDamping(state.reverb_damping)
+            end
+
+            for i = 0, state.num_faders - 1 do
+                engine.setVoiceEnvelope(i, state.env_attack, state.env_decay, state.env_sustain, state.env_release)
             end
         end
         
@@ -1936,8 +1916,28 @@ function enc(n, delta)
                 update_all_notes()
             end
         end
-        
+
     elseif state.current_page == 7 then
+        -- FX page (reverb)
+        if n == 2 then
+            state.selected_param = util.wrap(state.selected_param + delta, 1, 3)
+        elseif n == 3 then
+            if state.selected_param == 1 then
+                -- Reverb Mix
+                state.reverb_mix = util.clamp(state.reverb_mix + (delta * 0.05), 0.0, 1.0)
+                engine.setReverbMix(state.reverb_mix)
+            elseif state.selected_param == 2 then
+                -- Reverb Time
+                state.reverb_time = util.clamp(state.reverb_time + (delta * 0.1), 0.1, 10.0)
+                engine.setReverbTime(state.reverb_time)
+            elseif state.selected_param == 3 then
+                -- Reverb Damping
+                state.reverb_damping = util.clamp(state.reverb_damping + (delta * 0.05), 0.0, 1.0)
+                engine.setReverbDamping(state.reverb_damping)
+            end
+        end
+
+    elseif state.current_page == 8 then
         -- MIDI settings page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 2)
@@ -1950,8 +1950,8 @@ function enc(n, delta)
                 MidiHandler.set_fader_cc_start(new_cc)
             end
         end
-        
-    elseif state.current_page == 8 then
+
+    elseif state.current_page == 9 then
         -- LFO page
         if n == 2 then
             -- E2: Select parameter
@@ -2017,9 +2017,9 @@ function enc(n, delta)
                     lfo.dest_param = util.wrap(lfo.dest_param + delta, dest.param_min, dest.param_max)
                 end
             end
-        end    
-    
-    elseif state.current_page == 9 then
+        end
+
+    elseif state.current_page == 10 then
         -- SCENES page
         if n == 2 then
             state.scene_selected = util.wrap(state.scene_selected + delta, 1, 8)
@@ -2171,14 +2171,14 @@ function redraw()
     if selecting then
         return
     end
-    
+
     screen.clear()
-    
+
     screen.level(15)
     screen.move(64, 8)
-    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "SEQUENCER", "ENVELOPE", "SCALE", "MIDI", "LFO", "SCENES"}
+    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "SEQUENCER", "ENVELOPE", "SCALE", "FX", "MIDI", "LFO", "SCENES"}
     screen.text_center(pages[state.current_page])
-    
+
     if state.current_page == 1 then
         draw_play_page()
     elseif state.current_page == 2 then
@@ -2192,13 +2192,15 @@ function redraw()
     elseif state.current_page == 6 then
         draw_scale_page()
     elseif state.current_page == 7 then
-        draw_midi_page()
+        draw_fx_page()
     elseif state.current_page == 8 then
-        draw_lfo_page()
+        draw_midi_page()
     elseif state.current_page == 9 then
+        draw_lfo_page()
+    elseif state.current_page == 10 then
         draw_scenes_page()
     end
-    
+
     screen.update()
 end
 
@@ -2744,11 +2746,11 @@ function draw_sequencer_page()
 end
 
 function draw_envelope_page()
-    -- Draw envelope visualization (smaller, at top)
+    -- Draw envelope visualization (larger, centered)
     local env_x = 14
-    local env_y = 35
+    local env_y = 50
     local env_width = 100
-    local env_height = -20
+    local env_height = -30
 
     local total_time = state.env_attack + state.env_decay + 0.2 + state.env_release
     local a_width = (state.env_attack / total_time) * env_width
@@ -2764,41 +2766,55 @@ function draw_envelope_page()
     screen.line(env_x + a_width + d_width + s_width + r_width, env_y)
     screen.stroke()
 
-    -- Draw parameters in scrollable list
-    local params = {"Attack", "Decay", "Sustain", "Release", "Rvb Mix", "Rvb Time", "Rvb Damp"}
-    local param_start_y = 40
-    local param_spacing = 7
-    local visible_params = 3
+    -- Draw parameters horizontally at bottom with units
+    local params = {
+        {label = "A", value = string.format("%.2fs", state.env_attack), x = 0},
+        {label = "D", value = string.format("%.2fs", state.env_decay), x = 32},
+        {label = "S", value = string.format("%.2f", state.env_sustain), x = 64},
+        {label = "R", value = string.format("%.2fs", state.env_release), x = 94}
+    }
 
-    local scroll_offset = 0
-    if state.selected_param > visible_params then
-        scroll_offset = -(state.selected_param - visible_params) * param_spacing
+    for i = 1, 4 do
+        local param = params[i]
+        local is_selected = (state.selected_param == i)
+
+        screen.level(is_selected and 15 or 8)
+        screen.move(param.x, 60)
+        screen.text(param.label .. ": " .. param.value)
+
+        -- Draw selection indicator (underline)
+        if is_selected then
+            screen.level(15)
+            local text_width = #(param.label .. ": " .. param.value) * 4
+            screen.move(param.x, 62)
+            screen.line(param.x + text_width, 62)
+            screen.stroke()
+        end
     end
+end
 
-    for i = 1, 7 do
-        local y = param_start_y + (i * param_spacing) + scroll_offset
+function draw_fx_page()
+    screen.level(10)
 
-        if y > 38 and y < 64 then
-            screen.level(state.selected_param == i and 15 or 6)
-            screen.move(4, y)
-            screen.text(params[i] .. ":")
+    -- Title
+    screen.move(4, 10)
+    screen.text("FX - REVERB")
 
-            screen.move(60, y)
-            if i == 1 then
-                screen.text(string.format("%.2fs", state.env_attack))
-            elseif i == 2 then
-                screen.text(string.format("%.2fs", state.env_decay))
-            elseif i == 3 then
-                screen.text(string.format("%.2f", state.env_sustain))
-            elseif i == 4 then
-                screen.text(string.format("%.2fs", state.env_release))
-            elseif i == 5 then
-                screen.text(string.format("%d%%", math.floor(state.reverb_mix * 100)))
-            elseif i == 6 then
-                screen.text(string.format("%.1fs", state.reverb_time))
-            elseif i == 7 then
-                screen.text(string.format("%d%%", math.floor(state.reverb_damping * 100)))
-            end
+    -- Draw parameters
+    local params = {"Mix", "Time", "Damping"}
+    for i = 1, 3 do
+        local y = 20 + (i * 10)
+        screen.level(state.selected_param == i and 15 or 6)
+        screen.move(4, y)
+        screen.text(params[i] .. ":")
+
+        screen.move(60, y)
+        if i == 1 then
+            screen.text(string.format("%d%%", math.floor(state.reverb_mix * 100)))
+        elseif i == 2 then
+            screen.text(string.format("%.1fs", state.reverb_time))
+        elseif i == 3 then
+            screen.text(string.format("%d%%", math.floor(state.reverb_damping * 100)))
         end
     end
 end

--- a/strata.lua
+++ b/strata.lua
@@ -224,7 +224,7 @@ local state = {
     -- Gate threshold
     gate_threshold = 0.01,
 
-    -- MIDI keyboard support (chromatic, background, no velocity)
+    -- MIDI keyboard support (chromatic, background, with velocity)
     keyboard = {
         next_voice = 0,  -- Round-robin voice allocation (0-7)
         active_notes = {}  -- Maps MIDI note number to voice index
@@ -1475,7 +1475,7 @@ function release_note(fader_idx)
     engine.noteOff(fader_idx)
 end
 
--- MIDI Keyboard handlers (chromatic, always-on, no velocity)
+-- MIDI Keyboard handlers (chromatic, always-on, with velocity)
 function handle_note_on(note, vel)
     -- Ignore during recording
     if state.recording then
@@ -1502,15 +1502,18 @@ function handle_note_on(note, vel)
     -- A4 (MIDI 69) = 440 Hz
     local freq = 440 * math.pow(2, (note - 69) / 12)
 
+    -- Convert MIDI velocity (0-127) to position (0-1.0)
+    local velocity = vel / 127.0
+
     -- Track this note
     state.keyboard.active_notes[note] = voice
 
     -- Advance to next voice (round-robin 0-7)
     state.keyboard.next_voice = (voice + 1) % 8
 
-    -- Trigger note on engine (no velocity, full position)
+    -- Trigger note on engine with velocity
     engine.noteOn(voice, freq)
-    engine.setFaderPos(voice, 1.0)  -- Full velocity (no velocity sensitivity)
+    engine.setFaderPos(voice, velocity)
 end
 
 function handle_note_off(note, vel)

--- a/test.md
+++ b/test.md
@@ -1,0 +1,1 @@
+test file to see if syncing is working


### PR DESCRIPTION
Implements a new Play Mode page (page 4) that provides three ways to
trigger fader voices:

1. CHORD MODE (default):
   - All faders trigger simultaneously (existing normal behavior)
   - No additional parameters

2. STRUM MODE:
   - Triggers faders sequentially in a one-shot pattern
   - Only applies to snapshot triggers (sequencer or manual K2 jump)
   - Configurable rate (10-500ms) and pattern (up/down/updown/random)
   - Manual K2 trigger for immediate strum

3. ARP MODE:
   - Triggers faders sequentially in a looping pattern
   - Two sources: Snapshot (fixed positions) or Live (real-time updates)
   - BPM-synced rate with multiple divisions (1/16 to 1/1)
   - Configurable pattern (up/down/updown/random)
   - Gate length options (staccato/normal/legato)
   - K2 toggle for arp on/off

Key implementation details:
- Added play_mode state structure with all mode parameters
- Implemented core functions: get_active_faders(), get_next_play_mode_fader(),
  play_mode_clock(), start_play_mode(), stop_play_mode()
- Integrated with start_morph() for automatic strum on snapshot changes
- Updated page numbering: SEQUENCER→5, ENVELOPE→6, SCALE→7, MIDI→8, LFO→9, SCENES→10
- Added encoder handlers for all play mode parameters
- Added key handlers (K2 for mode-specific actions, K3 reserved)
- Created draw_play_mode_page() with mode-specific UI
- Scene save/load support for all play mode parameters
- Automatically stops arp when switching modes or loading scenes

Follows existing strata code patterns for clock management, UI layout,
and parameter handling.