### PR TITLE
Add Smooth Random LFO type

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -130,7 +130,7 @@ local state = {
     },
     
     -- LFO shape names
-    lfo_shape_names = {"Sine", "Triangle", "Square", "Random"},
+    lfo_shape_names = {"Sine", "Triangle", "Square", "Random", "Smooth Random"},
     
     -- LFO BPM divisions
     lfo_bpm_divisions = {
@@ -238,6 +238,7 @@ end
 -- Initialize LFO random values
 for i = 1, state.lfo_count do
     state.lfos[i].random_value = 0
+    state.lfos[i].next_random_value = (math.random() * 2) - 1
     state.lfos[i].last_phase = 0
 end
 
@@ -275,8 +276,20 @@ function calculate_lfo_value(lfo)
             lfo.random_value = (math.random() * 2) - 1
         end
         value = lfo.random_value or 0
+    elseif lfo.shape == 5 then
+        -- Smooth Random (interpolated random)
+        -- Smoothly glides from one random value to the next
+        if phase < lfo.last_phase then
+            -- Phase wrapped - move to next random value
+            lfo.random_value = lfo.next_random_value or 0
+            lfo.next_random_value = (math.random() * 2) - 1
+        end
+        -- Linear interpolation between current and next random value
+        local current = lfo.random_value or 0
+        local next = lfo.next_random_value or 0
+        value = current + (next - current) * phase
     end
-    
+
     lfo.last_phase = phase
     return value
 end
@@ -1931,7 +1944,7 @@ function enc(n, delta)
                 end
             elseif state.lfo_selected_param == 3 then
                 -- Shape
-                lfo.shape = util.wrap(lfo.shape + delta, 1, 4)
+                lfo.shape = util.wrap(lfo.shape + delta, 1, 5)
             elseif state.lfo_selected_param == 4 then
                 -- Rate mode
                 if delta ~= 0 then


### PR DESCRIPTION
Implements a new "Smooth Random" LFO shape that smoothly interpolates between random values instead of stepping abruptly like the regular Random LFO. This creates smooth, organic modulation movements.

Changes:
- Added "Smooth Random" to lfo_shape_names (shape 5)
- Initialized next_random_value field for smooth interpolation
- Implemented linear interpolation between random values based on phase
- Updated UI to allow selecting the new shape (1-5 instead of 1-4)

The Smooth Random LFO generates a new random target value at each cycle wrap and smoothly glides from the current value to the next using linear interpolation, creating fluid modulation patterns.