### PR TITLE
Add unified Play Mode feature with Chord, Strum, and Arp modes

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -214,7 +214,33 @@ local state = {
         progress = 0,
         manual_override = {}
     },
-    
+
+    -- Play mode system
+    play_mode = {
+        mode = "chord",  -- "chord", "strum", "arp"
+
+        -- Strum parameters
+        strum_rate_ms = 50,  -- 10-500ms between steps
+        strum_pattern = "up",  -- "up", "down", "updown", "random"
+
+        -- Arp parameters
+        arp_rate_div = 3,  -- Index into lfo_bpm_divisions (1/4 note default)
+        arp_pattern = "up",  -- "up", "down", "updown", "random"
+        arp_gate_length = 0.5,  -- 0.25 (staccato), 0.5 (normal), 0.9 (legato)
+        arp_source = "snapshot",  -- "snapshot" or "live"
+        arp_enabled = false,  -- Toggle arp on/off
+
+        -- Playback state
+        playing = false,
+        current_step = 1,
+        active_faders = {},  -- List of fader indices with position > threshold
+        direction = 1,  -- For updown pattern (1 or -1)
+        clock_id = nil,
+
+        -- Selected parameter for UI
+        selected_param = 1
+    },
+
     -- UI state
     current_page = 1,
     selected_param = 1,
@@ -699,6 +725,178 @@ function get_next_snapshot_index()
     end
 end
 
+-- ===================================
+-- PLAY MODE SYSTEM
+-- ===================================
+
+-- Get list of active faders (position > threshold)
+function get_active_faders()
+    local active = {}
+    for i = 0, 7 do
+        if state.faders[i].position > state.gate_threshold then
+            table.insert(active, i)
+        end
+    end
+    return active
+end
+
+-- Get next fader index based on pattern
+function get_next_play_mode_fader()
+    local active = state.play_mode.active_faders
+
+    if #active == 0 then
+        return nil
+    end
+
+    local pattern = state.play_mode.mode == "strum" and state.play_mode.strum_pattern or state.play_mode.arp_pattern
+    local step = state.play_mode.current_step
+
+    if pattern == "up" then
+        local idx = active[step]
+        state.play_mode.current_step = (step % #active) + 1
+        return idx
+
+    elseif pattern == "down" then
+        local idx = active[#active - step + 1]
+        state.play_mode.current_step = (step % #active) + 1
+        return idx
+
+    elseif pattern == "updown" then
+        -- Bounce back and forth
+        local effective_length = (#active * 2) - 2
+        if effective_length <= 0 then
+            effective_length = 1
+        end
+
+        local pos = ((step - 1) % effective_length) + 1
+        local idx
+
+        if pos <= #active then
+            idx = active[pos]
+        else
+            idx = active[#active - (pos - #active)]
+        end
+
+        state.play_mode.current_step = step + 1
+        return idx
+
+    elseif pattern == "random" then
+        local idx = active[math.random(1, #active)]
+        state.play_mode.current_step = step + 1
+        return idx
+    end
+
+    return nil
+end
+
+-- Calculate step duration based on mode
+function get_play_mode_step_duration()
+    if state.play_mode.mode == "strum" then
+        return state.play_mode.strum_rate_ms / 1000.0
+    elseif state.play_mode.mode == "arp" then
+        local bpm = state.snapshot_player.bpm
+        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats
+        return (beats / bpm) * 60.0
+    end
+    return 0.1  -- Fallback
+end
+
+-- Trigger note for a specific fader
+function trigger_play_mode_note(fader_idx)
+    local f = state.faders[fader_idx]
+    if f.position > state.gate_threshold then
+        engine.trigger(fader_idx, f.position)
+    end
+end
+
+-- Release note for a specific fader
+function release_play_mode_note(fader_idx)
+    engine.release(fader_idx)
+end
+
+-- Main playback clock
+function play_mode_clock()
+    while state.play_mode.playing do
+        -- Update active faders list (for live arp)
+        if state.play_mode.mode == "arp" and state.play_mode.arp_source == "live" then
+            state.play_mode.active_faders = get_active_faders()
+        end
+
+        -- Get next fader to trigger
+        local fader_idx = get_next_play_mode_fader()
+
+        if fader_idx then
+            -- Trigger the note
+            trigger_play_mode_note(fader_idx)
+
+            -- Handle gate length (arp mode only)
+            if state.play_mode.mode == "arp" then
+                clock.run(function()
+                    local duration = get_play_mode_step_duration()
+                    clock.sleep(duration * state.play_mode.arp_gate_length)
+                    release_play_mode_note(fader_idx)
+                end)
+            end
+        end
+
+        -- Wait for next step
+        clock.sleep(get_play_mode_step_duration())
+
+        -- Stop if strum mode and completed one cycle
+        if state.play_mode.mode == "strum" then
+            local pattern = state.play_mode.strum_pattern
+            local max_steps = #state.play_mode.active_faders
+
+            if pattern == "updown" then
+                max_steps = (max_steps * 2) - 2
+                if max_steps <= 0 then
+                    max_steps = 1
+                end
+            end
+
+            if state.play_mode.current_step > max_steps then
+                stop_play_mode()
+            end
+        end
+    end
+end
+
+-- Start play mode (called when snapshot triggers or arp toggled)
+function start_play_mode(source_faders)
+    -- Capture fader positions
+    state.play_mode.active_faders = source_faders or get_active_faders()
+
+    if #state.play_mode.active_faders == 0 then
+        return  -- Nothing to play
+    end
+
+    -- Stop existing playback
+    if state.play_mode.playing then
+        stop_play_mode()
+    end
+
+    -- Reset state
+    state.play_mode.current_step = 1
+    state.play_mode.direction = 1
+    state.play_mode.playing = true
+
+    -- Start clock
+    state.play_mode.clock_id = clock.run(play_mode_clock)
+end
+
+-- Stop play mode
+function stop_play_mode()
+    state.play_mode.playing = false
+    if state.play_mode.clock_id then
+        clock.cancel(state.play_mode.clock_id)
+        state.play_mode.clock_id = nil
+    end
+end
+
+-- ===================================
+-- MORPHING & SNAPSHOTS
+-- ===================================
+
 function start_morph(to_idx)
     if to_idx == "rest" then
         -- Morph all faders to zero
@@ -749,8 +947,22 @@ function start_morph(to_idx)
     end
     
     state.snapshot_current = to_idx
-    
+
     print("Morphing to snapshot " .. to_idx)
+
+    -- Trigger play mode if strum is enabled
+    if state.play_mode.mode == "strum" then
+        -- Get active faders from the target snapshot
+        local active_faders = {}
+        for i = 0, 7 do
+            if state.snapshots[to_idx].positions[i] > state.gate_threshold then
+                table.insert(active_faders, i)
+            end
+        end
+        if #active_faders > 0 then
+            start_play_mode(active_faders)
+        end
+    end
 end
 
 function jump_to_snapshot(idx)
@@ -1001,7 +1213,16 @@ function save_scene(slot)
         snapshot_player_euclidean_pulses = state.snapshot_player.euclidean_pulses,
         snapshot_player_euclidean_steps = state.snapshot_player.euclidean_steps,
         snapshot_player_euclidean_rotation = state.snapshot_player.euclidean_rotation,
-        snapshot_player_euclidean_rest_behavior = state.snapshot_player.euclidean_rest_behavior
+        snapshot_player_euclidean_rest_behavior = state.snapshot_player.euclidean_rest_behavior,
+
+        -- Play mode
+        play_mode_mode = state.play_mode.mode,
+        play_mode_strum_rate_ms = state.play_mode.strum_rate_ms,
+        play_mode_strum_pattern = state.play_mode.strum_pattern,
+        play_mode_arp_rate_div = state.play_mode.arp_rate_div,
+        play_mode_arp_pattern = state.play_mode.arp_pattern,
+        play_mode_arp_gate_length = state.play_mode.arp_gate_length,
+        play_mode_arp_source = state.play_mode.arp_source
     }
     
     -- Deep copy snapshots
@@ -1127,7 +1348,22 @@ function load_scene(slot)
     state.snapshot_player.euclidean_steps = scene.snapshot_player_euclidean_steps
     state.snapshot_player.euclidean_rotation = scene.snapshot_player_euclidean_rotation
     state.snapshot_player.euclidean_rest_behavior = scene.snapshot_player_euclidean_rest_behavior
-    
+
+    -- Load play mode
+    state.play_mode.mode = scene.play_mode_mode or "chord"
+    state.play_mode.strum_rate_ms = scene.play_mode_strum_rate_ms or 50
+    state.play_mode.strum_pattern = scene.play_mode_strum_pattern or "up"
+    state.play_mode.arp_rate_div = scene.play_mode_arp_rate_div or 3
+    state.play_mode.arp_pattern = scene.play_mode_arp_pattern or "up"
+    state.play_mode.arp_gate_length = scene.play_mode_arp_gate_length or 0.5
+    state.play_mode.arp_source = scene.play_mode_arp_source or "snapshot"
+
+    -- Stop any active arp if loading scene
+    if state.play_mode.playing then
+        stop_play_mode()
+    end
+    state.play_mode.arp_enabled = false
+
     -- Reset sequencer state
     state.snapshot_player.pattern_position = 1
     state.snapshot_player.euclidean_pattern = {}
@@ -1795,10 +2031,10 @@ function enc(n, delta)
     if n == 1 then
     -- Page navigation
     local old_page = state.current_page
-    state.current_page = util.clamp(state.current_page + delta, 1, 10)
-    
+    state.current_page = util.clamp(state.current_page + delta, 1, 11)
+
     -- Reset parameter selection when entering LFO page
-    if state.current_page == 9 and old_page ~= 9 then
+    if state.current_page == 10 and old_page ~= 10 then
         state.lfo_selected_param = 1
         -- Also ensure lfo_selected is valid
         state.lfo_selected = util.clamp(state.lfo_selected, 1, state.lfo_count)
@@ -1938,8 +2174,111 @@ function enc(n, delta)
                 state.snapshot_selected = util.wrap(state.snapshot_selected + delta, 1, 8)
             end
         end
-        
+
     elseif state.current_page == 4 then
+        -- PLAY MODE page
+        if n == 2 then
+            local max_params = 1
+            if state.play_mode.mode == "strum" then
+                max_params = 3
+            elseif state.play_mode.mode == "arp" then
+                max_params = 6
+            end
+            state.play_mode.selected_param = util.wrap(state.play_mode.selected_param + delta, 1, max_params)
+        elseif n == 3 then
+            if state.play_mode.selected_param == 1 then
+                -- Mode selection
+                local modes = {"chord", "strum", "arp"}
+                local current_idx = 1
+                for i, m in ipairs(modes) do
+                    if m == state.play_mode.mode then
+                        current_idx = i
+                        break
+                    end
+                end
+                local next_idx = util.wrap(current_idx + delta, 1, 3)
+                local old_mode = state.play_mode.mode
+                state.play_mode.mode = modes[next_idx]
+
+                -- Stop arp if switching away from arp mode
+                if old_mode == "arp" and state.play_mode.playing then
+                    stop_play_mode()
+                    state.play_mode.arp_enabled = false
+                end
+
+                -- Reset selected param when mode changes
+                state.play_mode.selected_param = 1
+
+            elseif state.play_mode.mode == "strum" then
+                if state.play_mode.selected_param == 2 then
+                    -- Strum rate
+                    state.play_mode.strum_rate_ms = util.clamp(
+                        state.play_mode.strum_rate_ms + (delta * 10), 10, 500
+                    )
+                elseif state.play_mode.selected_param == 3 then
+                    -- Strum pattern
+                    local patterns = {"up", "down", "updown", "random"}
+                    local current_idx = 1
+                    for i, p in ipairs(patterns) do
+                        if p == state.play_mode.strum_pattern then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 4)
+                    state.play_mode.strum_pattern = patterns[next_idx]
+                end
+
+            elseif state.play_mode.mode == "arp" then
+                if state.play_mode.selected_param == 2 then
+                    -- Arp rate (BPM division)
+                    state.play_mode.arp_rate_div = util.wrap(
+                        state.play_mode.arp_rate_div + delta, 1, #state.lfo_bpm_divisions
+                    )
+                elseif state.play_mode.selected_param == 3 then
+                    -- Arp pattern
+                    local patterns = {"up", "down", "updown", "random"}
+                    local current_idx = 1
+                    for i, p in ipairs(patterns) do
+                        if p == state.play_mode.arp_pattern then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 4)
+                    state.play_mode.arp_pattern = patterns[next_idx]
+                elseif state.play_mode.selected_param == 4 then
+                    -- Gate length
+                    local gates = {0.25, 0.5, 0.9}
+                    local current_idx = 2  -- Default to 0.5
+                    for i, g in ipairs(gates) do
+                        if math.abs(g - state.play_mode.arp_gate_length) < 0.01 then
+                            current_idx = i
+                            break
+                        end
+                    end
+                    local next_idx = util.wrap(current_idx + delta, 1, 3)
+                    state.play_mode.arp_gate_length = gates[next_idx]
+                elseif state.play_mode.selected_param == 5 then
+                    -- Source
+                    if delta ~= 0 then
+                        state.play_mode.arp_source = (state.play_mode.arp_source == "snapshot") and "live" or "snapshot"
+                    end
+                elseif state.play_mode.selected_param == 6 then
+                    -- Active toggle
+                    if delta ~= 0 then
+                        state.play_mode.arp_enabled = not state.play_mode.arp_enabled
+                        if state.play_mode.arp_enabled then
+                            start_play_mode()
+                        else
+                            stop_play_mode()
+                        end
+                    end
+                end
+            end
+        end
+
+    elseif state.current_page == 5 then
         -- SEQUENCER page
         if n == 2 then
             -- Determine number of params based on mode
@@ -2045,7 +2384,7 @@ function enc(n, delta)
             end
         end
     
-    elseif state.current_page == 5 then
+    elseif state.current_page == 6 then
         -- ENVELOPE page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 5)
@@ -2071,7 +2410,7 @@ function enc(n, delta)
             end
         end
         
-    elseif state.current_page == 6 then
+    elseif state.current_page == 7 then
         -- SCALE page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 3)
@@ -2088,7 +2427,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 7 then
+    elseif state.current_page == 8 then
         -- FX page (reverb)
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 8)
@@ -2128,7 +2467,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 8 then
+    elseif state.current_page == 9 then
         -- MIDI settings page
         if n == 2 then
             state.selected_param = util.wrap(state.selected_param + delta, 1, 2)
@@ -2142,7 +2481,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 9 then
+    elseif state.current_page == 10 then
         -- LFO page
         if n == 2 then
             -- E2: Select parameter
@@ -2210,7 +2549,7 @@ function enc(n, delta)
             end
         end
 
-    elseif state.current_page == 10 then
+    elseif state.current_page == 11 then
         -- SCENES page
         if n == 2 then
             state.scene_selected = util.wrap(state.scene_selected + delta, 1, 8)
@@ -2267,7 +2606,24 @@ function key(n, z)
                 else
                     jump_to_snapshot(state.snapshot_selected)
                 end
-            elseif state.current_page == 4 then 
+            elseif state.current_page == 4 then
+                -- PLAY MODE page: K2 action depends on mode
+                if state.play_mode.mode == "strum" then
+                    -- Manual strum trigger
+                    local active = get_active_faders()
+                    if #active > 0 then
+                        start_play_mode(active)
+                    end
+                elseif state.play_mode.mode == "arp" then
+                    -- Toggle arp on/off
+                    state.play_mode.arp_enabled = not state.play_mode.arp_enabled
+                    if state.play_mode.arp_enabled then
+                        start_play_mode()
+                    else
+                        stop_play_mode()
+                    end
+                end
+            elseif state.current_page == 5 then
                 -- SEQUENCER page
                 if state.snapshot_player.mode == "pattern" then
                     pattern_add_snapshot()
@@ -2280,7 +2636,7 @@ function key(n, z)
                     show_notification("REST: " .. string.upper(state.snapshot_player.euclidean_rest_behavior), 1.5)
                     save_snapshots_to_disk()
                 end
-            elseif state.current_page == 9 then
+            elseif state.current_page == 10 then
                 -- LFO page
                 local lfo = state.lfos[state.lfo_selected]
 
@@ -2299,7 +2655,7 @@ function key(n, z)
                         lfo.dest_param = util.wrap(lfo.dest_param + 1, dest.param_min, dest.param_max)
                     end
                 end
-            elseif state.current_page == 10 then
+            elseif state.current_page == 11 then
                 -- SCENES page: Save scene
                 save_scene(state.scene_selected)
             end
@@ -2329,6 +2685,9 @@ function key(n, z)
                     toggle_snapshot_enabled(state.snapshot_selected)
                 end
             elseif state.current_page == 4 then
+                -- PLAY MODE page: K3 reserved for future use
+                -- (no action currently)
+            elseif state.current_page == 5 then
                 -- SEQUENCER page
                 if state.snapshot_player.mode == "live" then
                     show_notification("LIVE MODE", 1.5)
@@ -2345,7 +2704,7 @@ function key(n, z)
                         start_snapshot_sequencer()
                     end
                 end
-            elseif state.current_page == 10 then
+            elseif state.current_page == 11 then
                 -- SCENES page
                 if state.k1_held then
                     clear_scene(state.scene_selected)
@@ -2367,7 +2726,7 @@ function redraw()
 
     screen.level(15)
     screen.move(64, 8)
-    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "SEQUENCER", "ENVELOPE", "SCALE", "FX", "MIDI", "LFO", "SCENES"}
+    local pages = {"PLAY", "SAMPLE", "SNAPSHOTS", "PLAY MODE", "SEQUENCER", "ENVELOPE", "SCALE", "FX", "MIDI", "LFO", "SCENES"}
     screen.text_center(pages[state.current_page])
 
     if state.current_page == 1 then
@@ -2377,18 +2736,20 @@ function redraw()
     elseif state.current_page == 3 then
         draw_snapshots_page()
     elseif state.current_page == 4 then
-        draw_sequencer_page()
+        draw_play_mode_page()
     elseif state.current_page == 5 then
-        draw_envelope_page()
+        draw_sequencer_page()
     elseif state.current_page == 6 then
-        draw_scale_page()
+        draw_envelope_page()
     elseif state.current_page == 7 then
-        draw_fx_page()
+        draw_scale_page()
     elseif state.current_page == 8 then
-        draw_midi_page()
+        draw_fx_page()
     elseif state.current_page == 9 then
-        draw_lfo_page()
+        draw_midi_page()
     elseif state.current_page == 10 then
+        draw_lfo_page()
+    elseif state.current_page == 11 then
         draw_scenes_page()
     end
 
@@ -2764,6 +3125,104 @@ function draw_snapshots_page()
     screen.level(6)
     screen.move(4, 64)
     screen.text("K2:Jump  K3:En/Dis  K1+K3:Del")
+end
+
+function draw_play_mode_page()
+    screen.level(10)
+
+    local y_offset = 18
+    local line_height = 10
+    local current_line = 0
+
+    -- Mode (always shown, param 1)
+    screen.level(state.play_mode.selected_param == 1 and 15 or 6)
+    screen.move(4, y_offset + (current_line * line_height))
+    local mode_display = state.play_mode.mode == "chord" and "Chord" or
+                         state.play_mode.mode == "strum" and "Strum" or "Arp"
+    screen.text("Mode: " .. mode_display)
+    current_line = current_line + 1
+
+    -- Mode-specific parameters
+    if state.play_mode.mode == "strum" then
+        -- Rate (param 2)
+        screen.level(state.play_mode.selected_param == 2 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("Rate: " .. state.play_mode.strum_rate_ms .. "ms")
+        current_line = current_line + 1
+
+        -- Pattern (param 3)
+        screen.level(state.play_mode.selected_param == 3 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local pattern_display = state.play_mode.strum_pattern == "updown" and "Up-Down" or
+                                string.upper(state.play_mode.strum_pattern:sub(1,1)) ..
+                                state.play_mode.strum_pattern:sub(2)
+        screen.text("Pattern: " .. pattern_display)
+        current_line = current_line + 1
+
+        -- K2 help text
+        screen.level(8)
+        screen.move(4, y_offset + (current_line * line_height) + 5)
+        screen.text("K2: Trigger Strum")
+
+    elseif state.play_mode.mode == "arp" then
+        -- Rate (param 2)
+        screen.level(state.play_mode.selected_param == 2 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local rate_name = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].name
+        screen.text("Rate: " .. rate_name)
+        current_line = current_line + 1
+
+        -- Pattern (param 3)
+        screen.level(state.play_mode.selected_param == 3 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local pattern_display = state.play_mode.arp_pattern == "updown" and "Up-Down" or
+                                string.upper(state.play_mode.arp_pattern:sub(1,1)) ..
+                                state.play_mode.arp_pattern:sub(2)
+        screen.text("Pattern: " .. pattern_display)
+        current_line = current_line + 1
+
+        -- Gate (param 4)
+        screen.level(state.play_mode.selected_param == 4 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local gate_name = state.play_mode.arp_gate_length == 0.25 and "Staccato" or
+                          state.play_mode.arp_gate_length == 0.5 and "Normal" or "Legato"
+        screen.text("Gate: " .. gate_name)
+        current_line = current_line + 1
+
+        -- Source (param 5)
+        screen.level(state.play_mode.selected_param == 5 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        local source_display = string.upper(state.play_mode.arp_source:sub(1,1)) ..
+                               state.play_mode.arp_source:sub(2)
+        screen.text("Source: " .. source_display)
+        current_line = current_line + 1
+
+        -- Active (param 6)
+        screen.level(state.play_mode.selected_param == 6 and 15 or 6)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("Active: " .. (state.play_mode.arp_enabled and "On" or "Off"))
+        current_line = current_line + 1
+
+        -- Status indicator
+        if state.play_mode.arp_enabled and state.play_mode.playing then
+            screen.level(15)
+            screen.move(128, y_offset)
+            screen.text_right("⏵")
+        end
+
+        -- K2 help text
+        screen.level(8)
+        screen.move(4, 64)
+        screen.text("K2: Toggle Arp")
+    else
+        -- Chord mode - just show description
+        screen.level(8)
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("All faders trigger")
+        current_line = current_line + 1
+        screen.move(4, y_offset + (current_line * line_height))
+        screen.text("simultaneously")
+    end
 end
 
 function draw_sequencer_page()


### PR DESCRIPTION
Implements a new Play Mode page (page 4) that provides three ways to trigger fader voices:

1. CHORD MODE (default):
   - All faders trigger simultaneously (existing normal behavior)
   - No additional parameters

2. STRUM MODE:
   - Triggers faders sequentially in a one-shot pattern
   - Only applies to snapshot triggers (sequencer or manual K2 jump)
   - Configurable rate (10-500ms) and pattern (up/down/updown/random)
   - Manual K2 trigger for immediate strum

3. ARP MODE:
   - Triggers faders sequentially in a looping pattern
   - Two sources: Snapshot (fixed positions) or Live (real-time updates)
   - BPM-synced rate with multiple divisions (1/16 to 1/1)
   - Configurable pattern (up/down/updown/random)
   - Gate length options (staccato/normal/legato)
   - K2 toggle for arp on/off

Key implementation details:
- Added play_mode state structure with all mode parameters
- Implemented core functions: get_active_faders(), get_next_play_mode_fader(), play_mode_clock(), start_play_mode(), stop_play_mode()
- Integrated with start_morph() for automatic strum on snapshot changes
- Updated page numbering: SEQUENCER→5, ENVELOPE→6, SCALE→7, MIDI→8, LFO→9, SCENES→10
- Added encoder handlers for all play mode parameters
- Added key handlers (K2 for mode-specific actions, K3 reserved)
- Created draw_play_mode_page() with mode-specific UI
- Scene save/load support for all play mode parameters
- Automatically stops arp when switching modes or loading scenes

Follows existing strata code patterns for clock management, UI layout, and parameter handling.