### PR TITLE
Fix OSC communication and level monitoring (#15)

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -311,8 +311,8 @@ Engine_Strata : CroneEngine {
                         postln("Mono sample converted and loaded: " ++ path);
                         postln("Frames=" ++ buffer.numFrames ++ " Duration=" ++ duration ++ "s");
 
-                        // Send duration to Lua via OSC
-                        context.server.addr.sendMsg("/sample_duration", duration);
+                        // Send duration to Lua via OSC (use norns OSC port)
+                        NetAddr("localhost", 10111).sendMsg("/sample_duration", duration);
 
                         // Trigger waveform generation
                         this.generateWaveform(buffer);
@@ -326,8 +326,8 @@ Engine_Strata : CroneEngine {
                         postln("Stereo sample loaded: " ++ path);
                         postln("Frames=" ++ buffer.numFrames ++ " Duration=" ++ duration ++ "s");
 
-                        // Send duration to Lua via OSC
-                        context.server.addr.sendMsg("/sample_duration", duration);
+                        // Send duration to Lua via OSC (use norns OSC port)
+                        NetAddr("localhost", 10111).sendMsg("/sample_duration", duration);
 
                         // Trigger waveform generation
                         this.generateWaveform(buffer);


### PR DESCRIPTION
Multiple critical fixes to make mono detection actually work:

OSC Fixes:
- Restore /input_levels OSC handler (was incorrectly removed)
- Fix SC OSC sending to use NetAddr("localhost", 10111) instead of context.server.addr
- Properly handle SendPeakRMS data format: [replyID, nodeID, peak_l, peak_r, rms_l, rms_r]

Level Monitoring Fixes:
- Remove broken audio.level_monitor_input() calls (doesn't exist in norns)
- Use engine.startInputMonitor() which sends levels via SendPeakRMS
- Add engine.stopInputMonitor() to both stop_recording and cancel_recording
- Track peak levels in OSC handler instead of recording clock

Recording Fixes:
- Simplify recording clock to only handle timeout checking
- Add debug logging for recording time tracking
- Add second-by-second time updates to debug timing issues

This should resolve:
- "FAILURE IN SERVER: /sample_duration Command not found" error
- "attempt to call a nil value (field 'level_monitor_input')" error
- Peak levels stuck at 0.000 (mono detection not working)