### PR TITLE
Fix cancel_recording - remove leftover poll cleanup code

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -1723,15 +1723,8 @@ function cancel_recording()
     softcut.enable(1, 0)
     softcut.enable(2, 0)
 
-    -- Stop input level polls
-    if state.recording_poll then
-        state.recording_poll:stop()
-        state.recording_poll = nil
-    end
-    if state.recording_poll_r then
-        state.recording_poll_r:stop()
-        state.recording_poll_r = nil
-    end
+    -- Stop engine monitoring
+    engine.stopInputMonitor()
 
     -- Stop recording clock
     if state.recording_clock then


### PR DESCRIPTION
The cancel_recording function still had references to state.recording_poll which no longer exists after switching to SC control buses. This was causing initialization errors.

Changed to use engine.stopInputMonitor() instead of poll cleanup.