### PR TITLE
Fix mono file buffer allocation and channel duplication

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -313,19 +313,24 @@ Engine_Strata : CroneEngine {
 
                 postln("Sample info: " ++ numChannels ++ " channels, " ++ numFrames ++ " frames, " ++ (numFrames / context.server.sampleRate) ++ "s");
 
-                // Handle mono files: read channel 0 into both buffer channels
+                // Handle mono files: allocate stereo buffer then read mono channel to both sides
                 if(numChannels == 1, {
                     postln("Loading mono file (will be converted to stereo during playback)...");
-                    buffer.allocReadChannel(path, 0, -1, [0, 0], {
-                        duration = buffer.numFrames / context.server.sampleRate;
-                        postln("Mono sample loaded: " ++ path);
-                        postln("Buffer frames=" ++ buffer.numFrames ++ " channels=" ++ buffer.numChannels ++ " Duration=" ++ duration ++ "s");
 
-                        // Send duration to Lua via OSC
-                        context.server.addr.sendMsg("/sample_duration", duration);
+                    // Allocate stereo buffer with correct size
+                    buffer.alloc(context.server, numFrames, 2, {
+                        // Read mono file channel 0 into both buffer channels [0, 0]
+                        buffer.readChannel(path, 0, -1, 0, false, [0, 0], {
+                            duration = buffer.numFrames / context.server.sampleRate;
+                            postln("Mono sample loaded: " ++ path);
+                            postln("Buffer frames=" ++ buffer.numFrames ++ " channels=" ++ buffer.numChannels ++ " Duration=" ++ duration ++ "s");
 
-                        // Trigger waveform generation
-                        this.generateWaveform(buffer);
+                            // Send duration to Lua via OSC
+                            context.server.addr.sendMsg("/sample_duration", duration);
+
+                            // Trigger waveform generation
+                            this.generateWaveform(buffer);
+                        });
                     });
                 }, {
                     // Stereo file: read normally


### PR DESCRIPTION
Previous fix had incorrect buffer allocation - it was keeping the 30-second pre-allocated buffer instead of resizing to the file.

Now properly:
1. Allocates a new stereo buffer matching the file's frame count
2. Uses readChannel to read mono channel 0 into both buffer channels

This ensures correct buffer size and proper stereo playback.