### PR TITLE
Update voice synths with new buffer number after sample load

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -327,8 +327,13 @@ Engine_Strata : CroneEngine {
                         postln("Mono sample loaded: " ++ path);
                         postln("Buffer frames=" ++ buf.numFrames ++ " channels=" ++ buf.numChannels ++ " Duration=" ++ duration ++ "s");
 
-                        // Send duration to Lua via OSC
-                        context.server.addr.sendMsg("/sample_duration", duration);
+                        // Update all voice synths with new buffer number
+                        8.do({ arg i;
+                            synths[i].set(\bufnum, buf.bufnum);
+                        });
+
+                        // Send duration to Lua via OSC (use NetAddr for norns)
+                        NetAddr("localhost", 10111).sendMsg("/sample_duration", duration);
 
                         // Trigger waveform generation
                         this.generateWaveform(buf);
@@ -341,8 +346,13 @@ Engine_Strata : CroneEngine {
                         postln("Stereo sample loaded: " ++ path);
                         postln("Buffer frames=" ++ buf.numFrames ++ " channels=" ++ buf.numChannels ++ " Duration=" ++ duration ++ "s");
 
-                        // Send duration to Lua via OSC
-                        context.server.addr.sendMsg("/sample_duration", duration);
+                        // Update all voice synths with new buffer number
+                        8.do({ arg i;
+                            synths[i].set(\bufnum, buf.bufnum);
+                        });
+
+                        // Send duration to Lua via OSC (use NetAddr for norns)
+                        NetAddr("localhost", 10111).sendMsg("/sample_duration", duration);
 
                         // Trigger waveform generation
                         this.generateWaveform(buf);


### PR DESCRIPTION
When loading a new sample, the buffer gets a new bufnum but the 8 voice synths were still referencing the old buffer number, causing "Buffer UGen: no buffer data" errors.

Fixed by:
- Updating all voice synths with buf.bufnum after loading
- Fixing OSC address to use NetAddr("localhost", 10111) for sample_duration message (matches waveform message routing)

This ensures voices can read the new buffer and Lua receives the correct sample duration.