### PR TITLE
Fix Play Mode: add safety checks to prevent clock hangs

### DIFF
--- a/strata.lua
+++ b/strata.lua
@@ -793,11 +793,11 @@ end
 -- Calculate step duration based on mode
 function get_play_mode_step_duration()
     if state.play_mode.mode == "strum" then
-        return state.play_mode.strum_rate_ms / 1000.0
+        return math.max(state.play_mode.strum_rate_ms / 1000.0, 0.01)
     elseif state.play_mode.mode == "arp" then
-        local bpm = state.snapshot_player.bpm
-        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats
-        return (beats / bpm) * 60.0
+        local bpm = math.max(state.snapshot_player.bpm or 120, 1)  -- Prevent division by zero
+        local beats = state.lfo_bpm_divisions[state.play_mode.arp_rate_div].beats or 1.0
+        return math.max((beats / bpm) * 60.0, 0.01)  -- Minimum 10ms
     end
     return 0.1  -- Fallback
 end


### PR DESCRIPTION
Added minimum duration checks and nil guards to prevent infinite loops:
- Minimum step duration of 10ms for both strum and arp modes
- Guard against bpm = 0 which would cause division by zero
- Guard against nil beats value from lfo_bpm_divisions array

This should prevent the script from hanging during initialization if play mode is accidentally triggered with invalid values.