### PR TITLE
Fix syntax error in Engine_Strata.sc tape FX implementation

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -618,6 +618,8 @@ Engine_Strata : CroneEngine {
         this.addCommand(\setTapeWidth, "f", { arg msg;
             var width = msg[1].asFloat.clip(0.0, 2.0);
             tapeSynth.set(\width, width);
+        });
+
         this.addCommand(\setMasterAmp, "f", { arg msg;
             var amp = msg[1].asFloat.clip(0.0, 1.0);
             reverbSynth.set(\amp, amp);


### PR DESCRIPTION
Fixed missing closing bracket for setTapeWidth command that was causing SUPERCOLLIDER FAIL error on engine initialization. This completes the tape FX implementation from issue #22.