### PR TITLE
Fix tape FX audio playback and UI selection issues

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -268,9 +268,10 @@ Engine_Strata : CroneEngine {
             // Read input
             sig = In.ar(in, 2);
             dry = sig;
+            wet = sig;
 
-            // Saturation (tape warmth/drive)
-            wet = (sig * (1 + (saturation * 2))).tanh;
+            // Saturation (tape warmth/drive) - only apply when saturation > 0
+            wet = wet + (((wet * (1 + (saturation * 2))).tanh - wet) * saturation);
 
             // Wow (slow pitch variation ~0.5Hz)
             wowLFO = LFNoise1.kr(0.5) * wow * 0.02;  // ±2% pitch variation

--- a/strata.lua
+++ b/strata.lua
@@ -3791,10 +3791,19 @@ function draw_fx_page()
     local param_spacing = 6
     local visible_rows = 7
 
+    -- Find the array index of the selected parameter
+    local selected_item_index = 0
+    for i, item in ipairs(items) do
+        if item.type == "param" and item.idx == state.selected_param then
+            selected_item_index = i
+            break
+        end
+    end
+
     -- Calculate scroll offset to keep selected param visible
     local scroll_offset = 0
-    if state.selected_param > visible_rows - 1 then
-        scroll_offset = -(state.selected_param - (visible_rows - 1)) * param_spacing
+    if selected_item_index > visible_rows then
+        scroll_offset = -(selected_item_index - visible_rows) * param_spacing
     end
 
     -- Draw all items with scrolling


### PR DESCRIPTION
1. Fixed no audible playback:
   - tapeFX SynthDef now properly passes dry signal when saturation=0
   - Previously applied .tanh to all audio even at neutral settings
   - Now blends saturated signal only when saturation > 0

2. Fixed tape FX parameter selection in UI:
   - Scrolling calculation now accounts for header items in the list
   - Tape parameters are now properly visible and selectable
   - Selected parameter stays in visible area when scrolling

Resolves playback and UI issues reported after initial tape FX merge.