### PR TITLE
Fix tape FX audio playback by bypassing PitchShift at defaults

### DIFF
--- a/lib/Engine_Strata.sc
+++ b/lib/Engine_Strata.sc
@@ -280,13 +280,14 @@ Engine_Strata : CroneEngine {
             flutterLFO = LFNoise1.kr(6) * flutter * 0.01;  // ±1% pitch variation
 
             // Combined pitch modulation via PitchShift
+            // Only apply when wow or flutter > 0 to avoid latency/artifacts
             pitchMod = wowLFO + flutterLFO;
-            wet = PitchShift.ar(
-                wet,
-                0.2,                           // Window size
-                1.0 + pitchMod,                // Pitch ratio
-                0.0,                           // Pitch dispersion
-                0.1                            // Time dispersion
+            wet = SelectX.ar(
+                (wow + flutter).clip(0, 1),  // Crossfade: 0 = bypass, >0 = process
+                [
+                    wet,  // Bypass (no pitch shift)
+                    PitchShift.ar(wet, 0.2, 1.0 + pitchMod, 0.0, 0.1)  // Pitch shifted
+                ]
             );
 
             // Compression (tape compression character)

--- a/strata.lua
+++ b/strata.lua
@@ -1704,6 +1704,18 @@ function init()
         engine.setReverbModDepth(state.reverb_mod_depth)
         engine.setReverbModFreq(state.reverb_mod_freq)
 
+        -- Set tape FX parameters
+        engine.setTapeMix(state.tape_mix)
+        engine.setTapeSaturation(state.tape_saturation)
+        engine.setTapeWow(state.tape_wow)
+        engine.setTapeFlutter(state.tape_flutter)
+        engine.setTapeAging(state.tape_aging)
+        engine.setTapeNoise(state.tape_noise)
+        engine.setTapeBias(state.tape_bias)
+        engine.setTapeCompression(state.tape_compression)
+        engine.setTapeDropout(state.tape_dropout)
+        engine.setTapeWidth(state.tape_width)
+
         -- Set master amp (ensure output is enabled on startup)
         engine.setMasterAmp(1)
 


### PR DESCRIPTION
Critical fix: PitchShift.ar() was being applied unconditionally even when wow=0 and flutter=0, introducing latency and artifacts that prevented audio playback. Now uses SelectX to bypass PitchShift when no modulation is active.

Also added explicit tape FX parameter initialization in init() to ensure all values are properly synchronized between Lua and SuperCollider on startup.

This resolves the no playback issue reported after tape FX merge.